### PR TITLE
Fix error if the first container is closed

### DIFF
--- a/ConcatenatedSorter.cs
+++ b/ConcatenatedSorter.cs
@@ -48,9 +48,15 @@ class ConcatenatedSorter : Sorter
         var grouped = containers.GroupBy(t => t.GetWindowSaveData(), new HashSetComparer());
         foreach (var group in grouped)
         {
-            SortInventory.Log($"Sorting group with {group.Count()} containers");
+            var ui = group.Select(container => GetUIInventoryForCard(container, backpack)).FirstOrDefault(ui => ui != null);
+            if (ui == null)
+            {
+                SortInventory.Log($"No UI found for group with {group.Count()} containers; ${group.First()}");
+                continue;
+            }
 
-            var ui = GetUIInventoryForCard(group.First(), backpack);
+            SortInventory.Log($"Sorting group with {group.Count()} containers; ${group.First()}");
+
             if (group.Count() == 1)
             {
                 ui.Sort();


### PR DESCRIPTION
If the first container in the group is closed, it causes a null pointer error. The `ui` is null for a closed container because it can't get the `ui` for a closed container.

Previously, it gets the ui only from the first container. To fix this problem, now it tries to get the ui from all containers. If no container opens, it does nothing.


This PR fixes the following comment on Steam workshop:

> Thank you for the mod! It's great! I did find an error, though. Conditions: When I have filled containers in main bag, then I have one bag closed and others open, if sort (concat=true) all my items are deleted. Luckily I had a save! I do have other mods as well.
