### PR TITLE
Add a new setting to ignore specified containers from sorting

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using BepInEx.Configuration;
 using UnityEngine;
 
@@ -9,6 +11,8 @@ public static class Settings
     public static ConfigEntry<KeyCode> keyCodeMod;
 
     public static ConfigEntry<bool> concatContainers;
+
+    public static ConfigEntry<string> ignoredContainerPattern;
 
     public static KeyCode KeyCode
     {
@@ -26,5 +30,11 @@ public static class Settings
     {
         get { return concatContainers.Value; }
         set { concatContainers.Value = value; }
+    }
+
+    public static List<string> IgnoredContainerPattern
+    {
+        get { return ignoredContainerPattern.Value.Split(',').Select(s => s.Trim()).Where(s => !string.IsNullOrEmpty(s)).ToList(); }
+        set { ignoredContainerPattern.Value = string.Join(",", value); }
     }
 }

--- a/SortInventory.cs
+++ b/SortInventory.cs
@@ -27,6 +27,7 @@ internal class SortInventory : BaseUnityPlugin
         Settings.keyCode = Config.Bind("Settings", "KeyCode", KeyCode.S, new ConfigDescription("Key to sort the inventory", null, null));
         Settings.keyCodeMod = Config.Bind("Settings", "KeyCodeMod", KeyCode.LeftAlt, new ConfigDescription("Modifier key to sort the inventory. If None is specified, it does not require a modifier key.", null, null));
         Settings.concatContainers = Config.Bind("Settings", "ConcatContainers", false, new ConfigDescription("If true, it treats containers having the same settings as one container. If false (default), it sorts containers independently.", null, null));
+        Settings.ignoredContainerPattern = Config.Bind("Settings", "IgnoredContainerPattern", "", new ConfigDescription("If specified, containers whose names match this pattern will be ignored when sorting. The patterns are a comma-separated strings.", null, null));
     }
 
     private void Update()

--- a/Sorter.cs
+++ b/Sorter.cs
@@ -1,11 +1,28 @@
 using System.Collections.Generic;
 using System.Linq;
 
+namespace SortInventory;
+
 class Sorter
 {
 
-    public static IEnumerable<Thing> GetContainersFromBackpack(LayerInventory backpack) {
-        return backpack.Inv.Container.things.Where(t => t.IsContainer && !IsContainerLocked(t) && t.things.owner.trait is not TraitToolBelt).ToList();
+    public static IEnumerable<Thing> GetContainersFromBackpack(LayerInventory backpack)
+    {
+        var containers = backpack.Inv.Container.things.Where(t => t.IsContainer && !IsContainerLocked(t) && t.things.owner.trait is not TraitToolBelt).ToList();
+
+        return containers.Where(container =>
+        {
+            var name = container.Name;
+            foreach (var pattern in Settings.IgnoredContainerPattern)
+            {
+                if (name.Contains(pattern))
+                {
+                    SortInventory.Log($"Ignoring container '{name}' matching pattern '{pattern}'");
+                    return false;
+                }
+            }
+            return true;
+        });
     }
 
     public static UIInventory GetUIInventoryForCard(Card card, LayerInventory backpack)


### PR DESCRIPTION
It adds a new setting to ignore specified containers from sorting.

Currently, this mod sorts all containers in the inventory. But some users want to keep the order.
The new setting solves this problem. The user can ignore specifeid containers by `IgnoredContainerPattern` setting. It's a comma-separated string. If the container name matches one of the patterns, this mod ignores the container from sorting.


Note: The pattern matches the default name of the container (e.g. sturdy box) or the name changed by the player.
